### PR TITLE
deprecated usage of ArrayAccess fixed in OpenPGP_CompressedDataPacket

### DIFF
--- a/lib/openpgp.php
+++ b/lib/openpgp.php
@@ -1692,7 +1692,7 @@ class OpenPGP_CompressedDataPacket extends OpenPGP_Packet implements IteratorAgg
     return isset($this->data[$offset]);
   }
 
-  function offsetGet($offset) {
+  function offsetGet($offset): mixed {
     return $this->data[$offset];
   }
 


### PR DESCRIPTION
Small improvement for PHP 8 support.

Will fix notice like this:

Return type of OpenPGP_CompressedDataPacket::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice