### PR TITLE
deprecated usage of ArrayAccess fixed in OpenPGP_Message

### DIFF
--- a/lib/openpgp.php
+++ b/lib/openpgp.php
@@ -389,7 +389,7 @@ class OpenPGP_Message implements IteratorAggregate, ArrayAccess {
     return isset($this->packets[$offset]);
   }
 
-  function offsetGet($offset) {
+  function offsetGet($offset): mixed {
     return $this->packets[$offset];
   }
 


### PR DESCRIPTION
Next fix for php8 support.

Deprecated error from logs:

Return type of OpenPGP_Message::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice